### PR TITLE
add singleThreaded option to groth16.fullProve

### DIFF
--- a/src/curves.js
+++ b/src/curves.js
@@ -18,10 +18,10 @@ export async function getCurveFromR(r) {
     return curve;
 }
 
-export async function getCurveFromQ(q) {
+export async function getCurveFromQ(q, singleThreaded = false) {
     let curve;
     if (Scalar.eq(q, bn128q)) {
-        curve = await buildBn128();
+        curve = await buildBn128(singleThreaded);
     } else if (Scalar.eq(q, bls12381q)) {
         curve = await buildBls12381();
     } else {

--- a/src/groth16_fullprove.js
+++ b/src/groth16_fullprove.js
@@ -22,12 +22,12 @@ import wtns_calculate from "./wtns_calculate.js";
 import {utils} from "ffjavascript";
 const {unstringifyBigInts} = utils;
 
-export default async function groth16FullProve(_input, wasmFile, zkeyFileName, logger) {
+export default async function groth16FullProve(_input, wasmFile, zkeyFileName, logger, singleThreaded = false) {
     const input = unstringifyBigInts(_input);
 
     const wtns= {
         type: "mem"
     };
     await wtns_calculate(input, wasmFile, wtns);
-    return await groth16_prove(zkeyFileName, wtns, logger);
+    return await groth16_prove(zkeyFileName, wtns, logger, singleThreaded);
 }

--- a/src/groth16_prove.js
+++ b/src/groth16_prove.js
@@ -25,14 +25,14 @@ import { log2 } from "./misc.js";
 import { Scalar, utils, BigBuffer } from "ffjavascript";
 const {stringifyBigInts} = utils;
 
-export default async function groth16Prove(zkeyFileName, witnessFileName, logger) {
+export default async function groth16Prove(zkeyFileName, witnessFileName, logger, singleThreaded = false) {
     const {fd: fdWtns, sections: sectionsWtns} = await binFileUtils.readBinFile(witnessFileName, "wtns", 2, 1<<25, 1<<23);
 
     const wtns = await wtnsUtils.readHeader(fdWtns, sectionsWtns);
 
     const {fd: fdZKey, sections: sectionsZKey} = await binFileUtils.readBinFile(zkeyFileName, "zkey", 2, 1<<25, 1<<23);
 
-    const zkey = await zkeyUtils.readHeader(fdZKey, sectionsZKey);
+    const zkey = await zkeyUtils.readHeader(fdZKey, sectionsZKey, singleThreaded);
 
     if (zkey.protocol != "groth16") {
         throw new Error("zkey file is not groth16");

--- a/src/groth16_prove.js
+++ b/src/groth16_prove.js
@@ -32,7 +32,7 @@ export default async function groth16Prove(zkeyFileName, witnessFileName, logger
 
     const {fd: fdZKey, sections: sectionsZKey} = await binFileUtils.readBinFile(zkeyFileName, "zkey", 2, 1<<25, 1<<23);
 
-    const zkey = await zkeyUtils.readHeader(fdZKey, sectionsZKey, singleThreaded);
+    const zkey = await zkeyUtils.readHeader(fdZKey, sectionsZKey, undefined, singleThreaded);
 
     if (zkey.protocol != "groth16") {
         throw new Error("zkey file is not groth16");

--- a/src/zkey_utils.js
+++ b/src/zkey_utils.js
@@ -205,7 +205,7 @@ async function readG2(fd, curve, toObject) {
 }
 
 
-export async function readHeader(fd, sections, toObject) {
+export async function readHeader(fd, sections, toObject, singleThreaded = false) {
     // Read Header
     /////////////////////
     await binFileUtils.startReadUniqueSection(fd, sections, 1);
@@ -213,7 +213,7 @@ export async function readHeader(fd, sections, toObject) {
     await binFileUtils.endReadSection(fd);
 
     if (protocolId === GROTH16_PROTOCOL_ID) {
-        return await readHeaderGroth16(fd, sections, toObject);
+        return await readHeaderGroth16(fd, sections, toObject, singleThreaded);
     } else if (protocolId === PLONK_PROTOCOL_ID) {
         return await readHeaderPlonk(fd, sections, toObject);
     } else if (protocolId === FFLONK_PROTOCOL_ID) {
@@ -226,7 +226,7 @@ export async function readHeader(fd, sections, toObject) {
 
 
 
-async function readHeaderGroth16(fd, sections, toObject) {
+async function readHeaderGroth16(fd, sections, toObject, singleThreaded = false) {
     const zkey = {};
 
     zkey.protocol = "groth16";
@@ -241,7 +241,7 @@ async function readHeaderGroth16(fd, sections, toObject) {
     const n8r = await fd.readULE32();
     zkey.n8r = n8r;
     zkey.r = await binFileUtils.readBigInt(fd, n8r);
-    zkey.curve = await getCurve(zkey.q);
+    zkey.curve = await getCurve(zkey.q, singleThreaded);
     zkey.nVars = await fd.readULE32();
     zkey.nPublic = await fd.readULE32();
     zkey.domainSize = await fd.readULE32();


### PR DESCRIPTION
When calling `groth16.fullProve` with bun (instead of node), the function `getCurveFromQ` hangs forever. I tracked this down a bit, and it seems the root cause is usage of the worker threads. Bun claims to have [supported](https://bun.sh/blog/bun-v0.7.2#node-js-worker-threads) this, but I was unable to get it working with changes further upstream. It's possible that bun doesn't fully support node Workers; it's also possible I wasn't making the correct upstream changes. However, this solution works for my use-case and should work for anyone else who wishes to use snarkjs with bun